### PR TITLE
PX-1975: Updated resources bundle

### DIFF
--- a/Sources/WebimMobileWidget/Classes/SDK Files/Extensions/UIView.swift
+++ b/Sources/WebimMobileWidget/Classes/SDK Files/Extensions/UIView.swift
@@ -95,7 +95,7 @@ extension UIView {
     
     func loadViewFromNib(_ nibName: String) -> UIView {
         
-        let nib = UINib(nibName: nibName, bundle: Bundle.main)
+        let nib = UINib(nibName: nibName, bundle: WidgetAppDelegate.bundle)
         return nib.instantiate(withOwner: nil, options: nil)[0] as! UIView
     }
     

--- a/Sources/WebimMobileWidget/Classes/SDK Files/WidgetAppDelegate.swift
+++ b/Sources/WebimMobileWidget/Classes/SDK Files/WidgetAppDelegate.swift
@@ -39,7 +39,14 @@ public class WidgetAppDelegate: WidgetAppDelegateProtocol {
     #if SWIFT_PACKAGE
         return Bundle.module
     #else
-        return Bundle(for: WidgetAppDelegate.self)
+        let bundle = Bundle(for: WidgetAppDelegate.self)
+        guard
+            let path = bundle.path(forResource: "WebimMobileWidgetResources", ofType: "bundle"),
+            let resourcesBundle = Bundle(path: path)
+        else {
+            return bundle
+        }
+        return resourcesBundle
     #endif
     }()
     

--- a/WebimMobileWidget.podspec
+++ b/WebimMobileWidget.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'WebimMobileWidget'
-  s.version          = '1.3.10'
+  s.version          = '1.3.11'
   s.summary          = 'Webim.ru mobile UI for client SDK iOS.'
 
   s.homepage         = 'https://webim.ru/integration/mobile-sdk/ios-sdk-howto/'
@@ -10,8 +10,12 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '13.0'
   s.swift_version = '5.5'
   s.source_files = 'Sources/WebimMobileWidget/Classes/**/*.{swift,strings}'
-  s.resources = 'Sources/WebimMobileWidget/Assets/**/*.{xib,strings}',
-  'Sources/WebimMobileWidget/Assets/WidgetImages.xcassets'
+  s.resource_bundles = {
+    'WebimMobileWidgetResources' => [
+      'Sources/WebimMobileWidget/Assets/WidgetImages.xcassets',
+      'Sources/WebimMobileWidget/Assets/**/*.{xib,strings}'
+    ]
+  }
   s.dependency 'WebimMobileSDK', '~> 3.42.0'
   s.dependency 'WebimKeyboard', '~> 1.0.3'
   s.dependency 'Cosmos', '~> 25.0.1'


### PR DESCRIPTION
### Причина изменений
Этот PR решает проблему с загрузкой ресурсов в модуле. Ранее ресурсы добавлялись через `resources = "..."` сразу в главный бандл из-за чего возникали конфликты при сборке aviasales тк дублировался Assets.car. Поменяла на resources_bundle, чтобы ресурсы упаковывались в отдельный бандл по аналогии с остальными используемыми фреймворками